### PR TITLE
Fix updated certificates to be b64 encoded as well

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/models/APISystemCertificateUpdate.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/models/APISystemCertificateUpdate.inc
@@ -66,7 +66,7 @@ class APISystemCertificateUpdate extends APIModel {
                 $this->errors[] = APIResponse\get(1003);
             }
             else {
-                $this->validated_data["crt"] = $crt;
+                $this->validated_data["crt"] = base64_encode($crt);
             }
         } else {
             $this->errors[] = APIResponse\get(1003);
@@ -94,7 +94,7 @@ class APISystemCertificateUpdate extends APIModel {
                 $this->errors[] = APIResponse\get(1049);
             }
             else {
-                $this->validated_data["prv"] = $key;
+                $this->validated_data["prv"] = base64_encode($key);
             }
         } else {
             $this->errors[] = APIResponse\get(1004);


### PR DESCRIPTION
This PR makes sure that updated certificates are also stored base64-encoded.
Fixes https://github.com/jaredhendrickson13/pfsense-api/issues/218